### PR TITLE
[BE/FE] 아이 목록 조회 API 구현 및 구독 요청 페이로드 수정

### DIFF
--- a/BE/sql/ddl.sql
+++ b/BE/sql/ddl.sql
@@ -84,11 +84,13 @@ CREATE TABLE subscription (
 CREATE TABLE pick_up_location (
     subscription_id	BIGINT UNSIGNED	PRIMARY KEY,
     start_address VARCHAR(255) NOT NULL,
+    start_detailed_address VARCHAR(255),
     start_latitude DOUBLE NOT NULL,
     start_longitude	DOUBLE NOT NULL,
-    end_address	VARCHAR(255) NOT NULL,
-    end_latitude DOUBLE	NOT NULL,
-    end_longitude DOUBLE NOT NULL,
+    goal_address VARCHAR(255) NOT NULL,
+    goal_detailed_address VARCHAR(255),
+    goal_latitude DOUBLE	NOT NULL,
+    goal_longitude DOUBLE NOT NULL,
     FOREIGN KEY (subscription_id) REFERENCES subscription(subscription_id)
 ) ENGINE=InnoDB;
 

--- a/BE/sql/ddl.sql
+++ b/BE/sql/ddl.sql
@@ -84,12 +84,12 @@ CREATE TABLE subscription (
 CREATE TABLE pick_up_location (
     subscription_id	BIGINT UNSIGNED	PRIMARY KEY,
     start_address VARCHAR(255) NOT NULL,
-    start_detailed_address VARCHAR(255),
+    start_detailed_address VARCHAR(255) NOT NULL,
     start_latitude DOUBLE NOT NULL,
     start_longitude	DOUBLE NOT NULL,
     goal_address VARCHAR(255) NOT NULL,
-    goal_detailed_address VARCHAR(255),
-    goal_latitude DOUBLE	NOT NULL,
+    goal_detailed_address VARCHAR(255) NOT NULL,
+    goal_latitude DOUBLE NOT NULL,
     goal_longitude DOUBLE NOT NULL,
     FOREIGN KEY (subscription_id) REFERENCES subscription(subscription_id)
 ) ENGINE=InnoDB;

--- a/BE/src/main/java/ifive/idrop/common/dto/CurrentPickUpResponse.java
+++ b/BE/src/main/java/ifive/idrop/common/dto/CurrentPickUpResponse.java
@@ -66,9 +66,9 @@ public class CurrentPickUpResponse {
                     .startAddress(location.getStartAddress())
                     .startLatitude(location.getStartLatitude())
                     .startLongitude(location.getStartLongitude())
-                    .endAddress(location.getEndAddress())
-                    .endLatitude(location.getEndLatitude())
-                    .endLongitude(location.getEndLongitude())
+                    .endAddress(location.getGoalAddress())
+                    .endLatitude(location.getGoalLatitude())
+                    .endLongitude(location.getGoalLongitude())
                     .build();
         }
     }

--- a/BE/src/main/java/ifive/idrop/common/util/RequestSchedule.java
+++ b/BE/src/main/java/ifive/idrop/common/util/RequestSchedule.java
@@ -14,10 +14,6 @@ import java.util.stream.Stream;
 public class RequestSchedule {
     private List<LocalDateTime> requestSchedule = new ArrayList<>();
 
-    public void addSchedule(LocalDateTime schedule) {
-        requestSchedule.add(schedule);
-    }
-
     public void sortSchedule() {
         Collections.sort(requestSchedule);
     }

--- a/BE/src/main/java/ifive/idrop/common/util/ScheduleUtils.java
+++ b/BE/src/main/java/ifive/idrop/common/util/ScheduleUtils.java
@@ -1,68 +1,16 @@
 package ifive.idrop.common.util;
 
 import ifive.idrop.common.exception.BusinessException;
-import ifive.idrop.domain.pickup.entity.PickUpSchedule;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
 import org.springframework.http.HttpStatus;
 
-import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.format.TextStyle;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
 
 public class ScheduleUtils {
-    public static List<String> DAY_OF_WEEKS; //["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
     public static final int EXPIRATION = 28; //4주의 유효 기간
-
-    static {
-        DAY_OF_WEEKS = Arrays.stream(DayOfWeek.values())
-                .map(d -> d.getDisplayName(TextStyle.SHORT, Locale.US))
-                .toList();
-    }
-
-    public static RequestSchedule parseToList(List<PickUpSchedule> pickUpScheduleList) {
-        RequestSchedule requestSchedule = new RequestSchedule();
-        LocalDateTime now = LocalDateTime.now().withSecond(0).withNano(0);
-        int dayOfToday = now.getDayOfWeek().getValue();
-
-        for (PickUpSchedule schedule : pickUpScheduleList) {
-            int i = schedule.getId().getDay().ordinal();
-            int difference = getDifferenceOfDayOfWeek(i + 1, dayOfToday);
-            for (int d = difference; d <= EXPIRATION; d += 7) {
-                if (d == 0)
-                    continue; //당일은 제외
-                requestSchedule.addSchedule(now.plusDays(d).withHour(schedule.getStartTime().getHour()).withMinute(schedule.getStartTime().getMinute()));
-            }
-        }
-        return requestSchedule;
-    }
-
-    public static RequestSchedule parseToList(JSONObject schedule) {
-        RequestSchedule requestSchedule = new RequestSchedule();
-        LocalDateTime now = LocalDateTime.now().withSecond(0).withNano(0);
-        int dayOfToday = now.getDayOfWeek().getValue();
-
-        for (int i = 0; i < 7; i++) {
-            Map<String, Integer> dayObject = (Map<String, Integer>) schedule.get(DAY_OF_WEEKS.get(i));
-            if (dayObject != null) {
-                Number hour = dayObject.get("hour");
-                Number minute = dayObject.get("min");
-                int difference = getDifferenceOfDayOfWeek(i + 1, dayOfToday);
-                for (int d = difference; d <= EXPIRATION; d += 7) {
-                    if (d == 0)
-                        continue; //당일은 제외
-                    requestSchedule.addSchedule(now.plusDays(d).withHour(hour.intValue()).withMinute(minute.intValue()));
-                }
-            }
-        }
-        return requestSchedule;
-    }
 
     public static JSONObject toJSONObject(String schedule) {
         JSONParser parser = new JSONParser();
@@ -73,10 +21,6 @@ public class ScheduleUtils {
             throw new BusinessException(HttpStatus.INTERNAL_SERVER_ERROR, e.getMessage(), "");
         }
         return scheduleJSON;
-    }
-
-    private static int getDifferenceOfDayOfWeek(int from, int to) {
-        return (from - to >= 0) ? from - to : from - to + 7;
     }
 
     public static LocalDate calculateStartDate(LocalDateTime modifiedDate) {

--- a/BE/src/main/java/ifive/idrop/domain/child/controller/ChildController.java
+++ b/BE/src/main/java/ifive/idrop/domain/child/controller/ChildController.java
@@ -1,0 +1,26 @@
+package ifive.idrop.domain.child.controller;
+
+import ifive.idrop.common.dto.BaseResponse;
+import ifive.idrop.domain.auth.resolver.Login;
+import ifive.idrop.domain.child.dto.ChildResponse;
+import ifive.idrop.domain.child.service.ChildService;
+import ifive.idrop.domain.parent.entity.Parent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/children")
+public class ChildController {
+    private final ChildService childService;
+
+    @GetMapping
+    public BaseResponse<List<ChildResponse>> getChildren(@Login Parent parent) {
+        List<ChildResponse> childResponseList = childService.findChildren(parent.getId());
+        return BaseResponse.of("success", childResponseList);
+    }
+}

--- a/BE/src/main/java/ifive/idrop/domain/child/dto/ChildResponse.java
+++ b/BE/src/main/java/ifive/idrop/domain/child/dto/ChildResponse.java
@@ -1,0 +1,29 @@
+package ifive.idrop.domain.child.dto;
+
+import ifive.idrop.domain.child.entity.Child;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+@Builder
+public class ChildResponse {
+    private Long childId;
+    private Long parentId;
+    private String name;
+    private LocalDate birthDate;
+    private String gender;
+    private String imageUrl;
+
+    public static ChildResponse from(Child child) {
+        return ChildResponse.builder()
+                .childId(child.getId())
+                .parentId(child.getParent().getId())
+                .name(child.getName())
+                .birthDate(child.getBirthDate())
+                .gender(child.getGender().getDesc())
+                .imageUrl(child.getImageUrl())
+                .build();
+    }
+}

--- a/BE/src/main/java/ifive/idrop/domain/child/repository/ChildRepository.java
+++ b/BE/src/main/java/ifive/idrop/domain/child/repository/ChildRepository.java
@@ -5,6 +5,7 @@ import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -18,5 +19,11 @@ public class ChildRepository {
 
     public Optional<Child> findById(Long childId) {
         return Optional.ofNullable(em.find(Child.class, childId));
+    }
+
+    public List<Child> findByParentId(Long parentId) {
+        return em.createQuery("SELECT c FROM Child c where c.parent.id =: parentId", Child.class)
+                .setParameter("parentId", parentId)
+                .getResultList();
     }
 }

--- a/BE/src/main/java/ifive/idrop/domain/child/service/ChildService.java
+++ b/BE/src/main/java/ifive/idrop/domain/child/service/ChildService.java
@@ -1,0 +1,23 @@
+package ifive.idrop.domain.child.service;
+
+import ifive.idrop.domain.child.dto.ChildResponse;
+import ifive.idrop.domain.child.repository.ChildRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ChildService {
+    private final ChildRepository childRepository;
+
+    public List<ChildResponse> findChildren(Long parentId) {
+        return childRepository.findByParentId(parentId)
+                .stream()
+                .map(ChildResponse::from)
+                .toList();
+    }
+}

--- a/BE/src/main/java/ifive/idrop/domain/driver/dto/DriverSubscribeInfoResponse.java
+++ b/BE/src/main/java/ifive/idrop/domain/driver/dto/DriverSubscribeInfoResponse.java
@@ -48,7 +48,7 @@ public class DriverSubscribeInfoResponse {
                 .startDate(startDate)
                 .endDate(endDate)
                 .startAddress(pickUpLocation.getStartAddress())
-                .endAddress(pickUpLocation.getEndAddress())
+                .endAddress(pickUpLocation.getGoalAddress())
                 .status(subscription.getStatus().getDesc())
 //                .schedule(toJSONObject(pickUpSubscription.getSchedule()))
                 .build();

--- a/BE/src/main/java/ifive/idrop/domain/driver/dto/DriverTodayRemainingPickUpResponse.java
+++ b/BE/src/main/java/ifive/idrop/domain/driver/dto/DriverTodayRemainingPickUpResponse.java
@@ -65,9 +65,9 @@ public class DriverTodayRemainingPickUpResponse {
                     .startAddress(location.getStartAddress())
                     .startLatitude(location.getStartLatitude())
                     .startLongitude(location.getStartLongitude())
-                    .endAddress(location.getEndAddress())
-                    .endLatitude(location.getEndLatitude())
-                    .endLongitude(location.getEndLongitude())
+                    .endAddress(location.getGoalAddress())
+                    .endLatitude(location.getGoalLatitude())
+                    .endLongitude(location.getGoalLongitude())
                     .build();
         }
     }

--- a/BE/src/main/java/ifive/idrop/domain/driver/repository/DriverRepository.java
+++ b/BE/src/main/java/ifive/idrop/domain/driver/repository/DriverRepository.java
@@ -31,11 +31,6 @@ public class DriverRepository {
                 .getResultList();
     }
 
-    public List<Driver> findAllDrivers() {
-        return em.createQuery("select d from Driver d", Driver.class)
-                .getResultList();
-    }
-
     public List<Object[]> findAllRunningPickUpInfoOrderByreservedTimeASC(Long driverId) {
         String query = "SELECT pui, pu.reservedTime\n" +
                 "FROM Subscription pui\n" +

--- a/BE/src/main/java/ifive/idrop/domain/parent/dto/ParentSubscribeInfoResponse.java
+++ b/BE/src/main/java/ifive/idrop/domain/parent/dto/ParentSubscribeInfoResponse.java
@@ -40,7 +40,7 @@ public class ParentSubscribeInfoResponse {
                 .startDate(startDate)
                 .endDate(endDate)
                 .startAddress(pickUpLocation.getStartAddress())
-                .endAddress(pickUpLocation.getEndAddress())
+                .endAddress(pickUpLocation.getGoalAddress())
                 .status(subscription.getStatus().getDesc())
                 .schedule(toJSONObject("pickUpSubscription.getSchedule()"))
                 .build();

--- a/BE/src/main/java/ifive/idrop/domain/parent/dto/PickUpHistoryResponse.java
+++ b/BE/src/main/java/ifive/idrop/domain/parent/dto/PickUpHistoryResponse.java
@@ -53,7 +53,7 @@ public class PickUpHistoryResponse {
                         .startTime(pickUpHistory.getStartTime())
                         .startImage(pickUpHistory.getStartImage())
                         .startAddress(pickUpHistory.getSubscription().getPickUpLocation().getStartAddress())
-                        .endAddress(pickUpHistory.getSubscription().getPickUpLocation().getEndAddress())
+                        .endAddress(pickUpHistory.getSubscription().getPickUpLocation().getGoalAddress())
                         .build();
             }
 
@@ -61,7 +61,7 @@ public class PickUpHistoryResponse {
                     .endTime(pickUpHistory.getEndTime())
                     .endImage(pickUpHistory.getEndImage())
                     .startAddress(pickUpHistory.getSubscription().getPickUpLocation().getStartAddress())
-                    .endAddress(pickUpHistory.getSubscription().getPickUpLocation().getEndAddress())
+                    .endAddress(pickUpHistory.getSubscription().getPickUpLocation().getGoalAddress())
                     .status("픽업 종료")
                     .build();
         }

--- a/BE/src/main/java/ifive/idrop/domain/parent/repository/ParentRepository.java
+++ b/BE/src/main/java/ifive/idrop/domain/parent/repository/ParentRepository.java
@@ -14,16 +14,8 @@ import java.util.Optional;
 public class ParentRepository {
     private final EntityManager em;
 
-    public Optional<Parent> findParent(Long parentId) {
+    public Optional<Parent> findById(Long parentId) {
         return Optional.ofNullable(em.find(Parent.class, parentId));
-    }
-
-    public Optional<Child> findChild(Long parentId) {
-        return em.createQuery("SELECT c FROM Child c where c.parent.id =: parentId", Child.class)
-                .setParameter("parentId", parentId)
-                .getResultList()
-                .stream()
-                .findAny();
     }
 
     public List<Object[]> findRunningPickUpInfo(Long parentId) {

--- a/BE/src/main/java/ifive/idrop/domain/pickup/entity/PickUpLocation.java
+++ b/BE/src/main/java/ifive/idrop/domain/pickup/entity/PickUpLocation.java
@@ -12,16 +12,18 @@ public class PickUpLocation {
     private Long subscriptionId;
     @Column(nullable = false)
     private String startAddress;
+    private String startDetailedAddress;
     @Column(nullable = false)
     private Double startLatitude;
     @Column(nullable = false)
     private Double startLongitude;
     @Column(nullable = false)
-    private String endAddress;
+    private String goalAddress;
+    private String goalDetailedAddress;
     @Column(nullable = false)
-    private Double endLatitude;
+    private Double goalLatitude;
     @Column(nullable = false)
-    private Double endLongitude;
+    private Double goalLongitude;
 
     @MapsId
     @OneToOne(fetch = FetchType.LAZY)
@@ -31,11 +33,13 @@ public class PickUpLocation {
     public static PickUpLocation createPickUpLocation(Subscription subscription, SubscriptionRequest subscriptionRequest) {
         PickUpLocation pickUpLocation = new PickUpLocation();
         pickUpLocation.startAddress = subscriptionRequest.getStartAddress();
+        pickUpLocation.startDetailedAddress = subscriptionRequest.getStartDetailedAddress();
         pickUpLocation.startLatitude = subscriptionRequest.getStartLatitude();
         pickUpLocation.startLongitude = subscriptionRequest.getStartLongitude();
-        pickUpLocation.endAddress = subscriptionRequest.getEndAddress();
-        pickUpLocation.endLatitude = subscriptionRequest.getEndLatitude();
-        pickUpLocation.endLongitude = subscriptionRequest.getEndLongitude();
+        pickUpLocation.goalAddress = subscriptionRequest.getGoalAddress();
+        pickUpLocation.goalDetailedAddress = subscriptionRequest.getGoalDetailedAddress();
+        pickUpLocation.goalLatitude = subscriptionRequest.getGoalLatitude();
+        pickUpLocation.goalLongitude = subscriptionRequest.getGoalLongitude();
         pickUpLocation.subscription = subscription;
         return pickUpLocation;
     }

--- a/BE/src/main/java/ifive/idrop/domain/subscription/dto/DriverSubscribeInfoResponse.java
+++ b/BE/src/main/java/ifive/idrop/domain/subscription/dto/DriverSubscribeInfoResponse.java
@@ -49,7 +49,7 @@ public class DriverSubscribeInfoResponse {
                 .startDate(startDate)
                 .endDate(endDate)
                 .startAddress(pickUpLocation.getStartAddress())
-                .endAddress(pickUpLocation.getEndAddress())
+                .endAddress(pickUpLocation.getGoalAddress())
                 .status(subscription.getStatus().getDesc())
 //                .schedule(toJSONObject(pickUpSubscription.getSchedule()))
                 .build();

--- a/BE/src/main/java/ifive/idrop/domain/subscription/dto/SubscriptionRequest.java
+++ b/BE/src/main/java/ifive/idrop/domain/subscription/dto/SubscriptionRequest.java
@@ -13,11 +13,13 @@ public class SubscriptionRequest {
     private Long driverId;
     private LocalDate startDate;
     private String startAddress;
+    private String startDetailedAddress;
     private Double startLatitude;
     private Double startLongitude;
-    private String endAddress;
-    private Double endLatitude;
-    private Double endLongitude;
+    private String goalAddress;
+    private String goalDetailedAddress;
+    private Double goalLatitude;
+    private Double goalLongitude;
     private Map<Day, LocalTime> schedule;
 }
 
@@ -29,9 +31,9 @@ public class SubscriptionRequest {
  *     "startAddress": "서울특별시 강남구 논현동 58-3 에티버스러닝 학동캠퍼스",
  *     "startLatitude": 37.5138649,
  *     "startLongitude": 127.0295296,
- *     "endAddress": "서울특별시 강남구 학동로31길 15 코마츠",
- *     "endLatitude": 37.51559,
- *     "endLongitude": 127.0316161,
+ *     "goalAddress": "서울특별시 강남구 학동로31길 15 코마츠",
+ *     "goalLatitude": 37.51559,
+ *     "goalLongitude": 127.0316161,
  *     "schedule": {
  *         "MON": "08:30",
  *         "WED": "09:30",

--- a/BE/src/main/java/ifive/idrop/domain/subscription/dto/SubscriptionResponse.java
+++ b/BE/src/main/java/ifive/idrop/domain/subscription/dto/SubscriptionResponse.java
@@ -41,7 +41,7 @@ public class SubscriptionResponse {
                 .expiredDate(subscription.getExpiredDate())
                 .status(subscription.getStatus().getDesc())
                 .startAddress(subscription.getPickUpLocation().getStartAddress())
-                .endAddress(subscription.getPickUpLocation().getEndAddress())
+                .endAddress(subscription.getPickUpLocation().getGoalAddress())
                 .schedule(schedule)
                 .build();
     }

--- a/BE/src/main/java/ifive/idrop/websocket/location/LocationWebSocketHandler.java
+++ b/BE/src/main/java/ifive/idrop/websocket/location/LocationWebSocketHandler.java
@@ -171,7 +171,7 @@ public class LocationWebSocketHandler extends TextWebSocketHandler {
                 .parentId((Long) childIdAndParentId[1])
                 .reservedTime(pickup.getReservedTime())
                 .startLocation(new Location(pickUpLocation.getStartLongitude(), pickUpLocation.getStartLatitude()))
-                .endLocation(new Location(pickUpLocation.getEndLongitude(), pickUpLocation.getEndLatitude()))
+                .endLocation(new Location(pickUpLocation.getGoalLongitude(), pickUpLocation.getGoalLatitude()))
                 .build();
         currentPickUps.put(driverId, currentPickUp);
         parentDriverSets.put((Long) childIdAndParentId[1], driverId);

--- a/FE/src/pages/DriverDetail/DriverDetail.tsx
+++ b/FE/src/pages/DriverDetail/DriverDetail.tsx
@@ -5,6 +5,7 @@ import { Footer } from '@/components/Footer/Footer';
 import { Header } from '@/components/Header/Header';
 import { BottomSheet } from '@/components/BottomSheet/BottomSheet';
 import { postSubscription } from '@/services/subscription';
+import { useFetch } from '@/hooks/useFetch';
 import styles from './DriverDetail.module.scss';
 import { type State as Schedule, useSchedule } from './useSchedule';
 import { useEffect, useState } from 'react';
@@ -31,9 +32,15 @@ export default function DriverDetail() {
   const {
     state: { startLocation, goalLocation, driver },
   } = useLocation();
-  const [children, setChildren] = useState();
   const { schedule, toggleDay, changeHour, changeMinute } = useSchedule();
-  useEffect(() => {}, []);
+
+  const [children, setChildren] = useState([]);
+  const { data } = useFetch('/api/children');
+  useEffect(() => {
+    if (data) {
+      setChildren(data.data);
+    }
+  }, [data]);
 
   const {
     driverId,
@@ -67,6 +74,7 @@ export default function DriverDetail() {
 
     const payload = {
       driverId,
+      childId: children[0].childId,
       startDate: getToday(),
       startAddress,
       startDetailedAddress,
@@ -92,7 +100,8 @@ export default function DriverDetail() {
   const isButtonActive =
     startLocation.address &&
     goalLocation.address &&
-    Object.keys(schedule).length > 0;
+    Object.keys(schedule).length > 0 &&
+    children.length > 0;
 
   return (
     <div className={styles.container}>

--- a/FE/src/pages/DriverDetail/DriverDetail.tsx
+++ b/FE/src/pages/DriverDetail/DriverDetail.tsx
@@ -4,9 +4,10 @@ import { TimeList } from './TimeList/TimeList';
 import { Footer } from '@/components/Footer/Footer';
 import { Header } from '@/components/Header/Header';
 import { BottomSheet } from '@/components/BottomSheet/BottomSheet';
-import { postSubscribe } from '@/services/parentsAPI';
+import { postSubscription } from '@/services/subscription';
 import styles from './DriverDetail.module.scss';
 import { type State as Schedule, useSchedule } from './useSchedule';
+import { useEffect, useState } from 'react';
 
 const formatSchedule = (schedule: Schedule) => {
   return Object.fromEntries(
@@ -30,6 +31,10 @@ export default function DriverDetail() {
   const {
     state: { startLocation, goalLocation, driver },
   } = useLocation();
+  const [children, setChildren] = useState();
+  const { schedule, toggleDay, changeHour, changeMinute } = useSchedule();
+  useEffect(() => {}, []);
+
   const {
     driverId,
     name,
@@ -40,7 +45,6 @@ export default function DriverDetail() {
     career,
     introduction,
   } = driver;
-  const { schedule, toggleDay, changeHour, changeMinute } = useSchedule();
 
   const handleSubmit = async (isButtonActive: boolean) => {
     if (!isButtonActive) {
@@ -76,7 +80,7 @@ export default function DriverDetail() {
     };
 
     try {
-      await postSubscribe(payload);
+      await postSubscription(payload);
       navigate('/subscription/confirmation');
     } catch (error) {
       console.error(error);

--- a/FE/src/services/children.ts
+++ b/FE/src/services/children.ts
@@ -1,0 +1,17 @@
+import { authRequest } from './authenticationAPI';
+import { BASE_URL } from '@/constants/constants';
+
+export const getChildren = async () => {
+  try {
+    const response = await authRequest(`${BASE_URL}/api/children`);
+    if (response.ok) {
+      return await response.json();
+    } else {
+      console.error('Failed to GET children');
+      return { data: [] };
+    }
+  } catch (error) {
+    console.error(error);
+    throw new Error('Faild to GET request');
+  }
+};

--- a/FE/src/services/parentsAPI.ts
+++ b/FE/src/services/parentsAPI.ts
@@ -39,24 +39,6 @@ export async function getDriverDetail(driverId) {
   }
 }
 
-export async function postSubscribe(subscribeOption) {
-  try {
-    const response = await authRequest(`${BASE_URL}/api/subscriptions`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(subscribeOption),
-    });
-
-    if (response.ok) {
-      console.log('Review submitted successfully.');
-    } else {
-      console.error('구독 요청 실패.');
-    }
-  } catch (error) {
-    throw error;
-  }
-}
-
 export async function getSubscriptionHistoryList() {
   try {
     const response = await authRequest(`${BASE_URL}/parent/subscribe/list`);

--- a/FE/src/services/subscription.ts
+++ b/FE/src/services/subscription.ts
@@ -1,0 +1,20 @@
+import { authRequest } from './authenticationAPI';
+import { BASE_URL } from '@/constants/constants';
+
+export const postSubscription = async (subscribeOption) => {
+  try {
+    const response = await authRequest(`${BASE_URL}/api/subscriptions`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(subscribeOption),
+    });
+
+    if (response.ok) {
+      console.log('Review submitted successfully.');
+    } else {
+      console.error('구독 요청 실패.');
+    }
+  } catch (error) {
+    throw error;
+  }
+};


### PR DESCRIPTION
## 작업 내용
### 1. (BE) PickUpLocation 엔티티 속성 변경
- endAddress, endLatitude, endLongitude 속성의 이름을 각각 goalAddress, goalLatitude, goalLongitude로 변경했습니다.
- startDetailedAddress와 goalDetailedAddress 속성을 추가했습니다.
- DDL에도 변경 내용을 반영했습니다.

### 2. (BE) 아이 목록 조회 API 구현
부모가 자신의 아이들을 조회하기 위한 API를 구현했습니다.

### 3. (FE) 구독 요청 페이로드에 childId 포함
기사를 선택하고 픽업 요일과 시간을 선택한 다음 구독 신청을 할 때, 요청의 페이로드에 childId가 포함되도록 변경했습니다. 위 2번에서 구현한 API를 요청해 아이 목록을 조회한 다음 목록에서 아이를 선택하도록 할 예정이지만, 현재는 임시로 첫 번째 아이를 자동으로 선택하도록 만들어 두었습니다.

---

이로써 부모가 출발지와 도착지를 설정하고 기사 목록을 조회한 후, 기사 목록에서 특정 기사를 선택해 픽업 요일과 시간을 선택하고 구독 신청을 하는 전체 플로우가 구현되었습니다. DB에도 구독 관련 정보가 잘 저장되는 것을 확인했습니다.